### PR TITLE
fix: dispatch.h import on case-sensitive macOS

### DIFF
--- a/mainthread/os_darwin.go
+++ b/mainthread/os_darwin.go
@@ -12,7 +12,7 @@ package mainthread
 #cgo CFLAGS: -x objective-c
 #cgo LDFLAGS: -framework Cocoa
 #import <Cocoa/Cocoa.h>
-#import <Dispatch/Dispatch.h>
+#import <dispatch/dispatch.h>
 
 extern void os_main(void);
 extern void wakeupMainThread(void);


### PR DESCRIPTION
ls $(xcrun --sdk macosx --show-sdk-path)/usr/include/*ispatch/*ispatch.h /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk/usr/include/dispatch/dispatch.h