### PR TITLE
Allow usage of X11 on other platforms, and add support for OpenBSD

### DIFF
--- a/hotkey_x11.c
+++ b/hotkey_x11.c
@@ -4,7 +4,7 @@
 //
 // Written by Changkun Ou <changkun.de>
 
-//go:build linux
+//go:build linux || openbsd
 
 #include <stdint.h>
 #include <stdio.h>

--- a/hotkey_x11.go
+++ b/hotkey_x11.go
@@ -4,12 +4,14 @@
 //
 // Written by Changkun Ou <changkun.de>
 
-//go:build linux
+//go:build linux || openbsd
 
 package hotkey
 
 /*
 #cgo LDFLAGS: -lX11
+#cgo openbsd LDFLAGS: -L/usr/X11R6/lib -lX11
+#cgo openbsd CFLAGS: -I/usr/X11R6/include
 
 #include <stdint.h>
 

--- a/hotkey_x11_test.go
+++ b/hotkey_x11_test.go
@@ -4,7 +4,7 @@
 //
 // Written by Changkun Ou <changkun.de>
 
-//go:build linux && cgo
+//go:build (linux || openbsd) && cgo
 
 package hotkey_test
 

--- a/mainthread/os.go
+++ b/mainthread/os.go
@@ -4,7 +4,7 @@
 //
 // Written by Changkun Ou <changkun.de>
 
-//go:build windows || linux || (darwin && !cgo)
+//go:build windows || linux || openbsd || (darwin && !cgo)
 
 package mainthread
 


### PR DESCRIPTION
To add OpenBSD support and for other platforms in the future I changed the file suffix from `_linux` to `_x11` first, and then adjusted the `go:build` tags.

It would be very easy to add FreeBSD and NetBSD, but I haven't tested those.