### PR TITLE
fix(linux): correct KeyTab keysym aliased to KeyEscape

### DIFF
--- a/hotkey_linux.go
+++ b/hotkey_linux.go
@@ -180,7 +180,7 @@ const (
 	KeyReturn Key = 0xff0d
 	KeyEscape Key = 0xff1b
 	KeyDelete Key = 0xffff
-	KeyTab    Key = 0xff1b
+	KeyTab    Key = 0xff09
 
 	KeyLeft  Key = 0xff51
 	KeyRight Key = 0xff53

--- a/hotkey_linux_test.go
+++ b/hotkey_linux_test.go
@@ -17,6 +17,26 @@ import (
 	"golang.design/x/hotkey"
 )
 
+// TestKeycodesAreDistinct guards against duplicated keysym constants.
+// KeyTab used to alias KeyEscape (both 0xff1b), which made Tab hotkeys
+// register Escape instead.
+func TestKeycodesAreDistinct(t *testing.T) {
+	keys := map[string]hotkey.Key{
+		"KeySpace": hotkey.KeySpace, "KeyReturn": hotkey.KeyReturn,
+		"KeyEscape": hotkey.KeyEscape, "KeyDelete": hotkey.KeyDelete,
+		"KeyTab":  hotkey.KeyTab,
+		"KeyLeft": hotkey.KeyLeft, "KeyRight": hotkey.KeyRight,
+		"KeyUp": hotkey.KeyUp, "KeyDown": hotkey.KeyDown,
+	}
+	seen := map[hotkey.Key]string{}
+	for name, code := range keys {
+		if prev, ok := seen[code]; ok {
+			t.Errorf("key %s and %s share the same keycode 0x%x", prev, name, code)
+		}
+		seen[code] = name
+	}
+}
+
 // TestHotkey should always run success.
 // This is a test to run and for manually testing, registered combination:
 // Ctrl+Alt+A (Ctrl+Mod2+Mod4+A on Linux)


### PR DESCRIPTION
On Linux/X11 `KeyTab` was defined as `0xff1b`, which is the `XK_Escape` keysym, so registering a Tab hotkey actually grabbed Escape. Corrected to `0xff09` (`XK_Tab`). Darwin and Windows already had Tab right.

Adds `TestKeycodesAreDistinct`, which fails without the fix and runs on Linux CI under Xvfb.

One fix, one PR (split out of #34).