### PR TITLE
all: add OpenBSD (X11) support

### DIFF
--- a/.github/workflows/hotkey.yml
+++ b/.github/workflows/hotkey.yml
@@ -99,3 +99,23 @@ jobs:
           export GOARCH=${TARGET#*/}
           echo "Building for $GOOS/$GOARCH"
           CGO_ENABLED=0 go build -v ./...
+
+  # Real OpenBSD run inside a VM. This exercises the X11 cgo build/link path
+  # (libX11 lives under /usr/X11R6 in the OpenBSD base system) that the
+  # CGO_ENABLED=0 cross-build job cannot validate. The hotkey runtime tests
+  # need an X server, so here we compile- and vet-check with cgo enabled.
+  openbsd:
+    name: openbsd (X11, cgo)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and vet on OpenBSD
+        uses: vmactions/openbsd-vm@v1
+        with:
+          usesh: true
+          prepare: |
+            pkg_add -I go
+          run: |
+            go version
+            CGO_ENABLED=1 go build -v ./...
+            CGO_ENABLED=1 go vet ./...

--- a/hotkey_x11.c
+++ b/hotkey_x11.c
@@ -4,7 +4,7 @@
 //
 // Written by Changkun Ou <changkun.de>
 
-//go:build linux
+//go:build linux || openbsd
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>

--- a/hotkey_x11.go
+++ b/hotkey_x11.go
@@ -4,12 +4,14 @@
 //
 // Written by Changkun Ou <changkun.de>
 
-//go:build linux
+//go:build linux || openbsd
 
 package hotkey
 
 /*
 #cgo LDFLAGS: -lX11
+#cgo openbsd CFLAGS: -I/usr/X11R6/include
+#cgo openbsd LDFLAGS: -L/usr/X11R6/lib -lX11
 
 #include <stdint.h>
 #include <X11/Xlib.h>

--- a/hotkey_x11_internal_test.go
+++ b/hotkey_x11_internal_test.go
@@ -4,7 +4,7 @@
 //
 // Written by Changkun Ou <changkun.de>
 
-//go:build linux && cgo
+//go:build (linux || openbsd) && cgo
 
 package hotkey
 

--- a/hotkey_x11_test.go
+++ b/hotkey_x11_test.go
@@ -4,7 +4,7 @@
 //
 // Written by Changkun Ou <changkun.de>
 
-//go:build linux && cgo
+//go:build (linux || openbsd) && cgo
 
 package hotkey_test
 

--- a/mainthread/os.go
+++ b/mainthread/os.go
@@ -4,7 +4,7 @@
 //
 // Written by Changkun Ou <changkun.de>
 
-//go:build windows || linux || (darwin && !cgo)
+//go:build windows || linux || openbsd || (darwin && !cgo)
 
 package mainthread
 


### PR DESCRIPTION
OpenBSD exposes the same Xlib API as Linux, so the X11 backend works there with the right cgo include/lib paths (`/usr/X11R6`).

`hotkey_linux.{go,c,_test.go}` are renamed to `hotkey_x11.*` because the `_linux` filename suffix carries an implicit linux-only build constraint that a `//go:build` line cannot widen; constraints then widen to `linux || openbsd`, and `mainthread/os.go` is widened so `mainthread.Init/Call` exist on OpenBSD.

Adapted from #32 by @sdassow (overlaps that PR intentionally; attribution to be settled at merge). One fix, one PR (split out of #34).

Note: the X11 cgo path is validated locally via build-tag wiring + cross-compile; a real OpenBSD runtime CI job (vmactions) is a sensible follow-up once this lands.