### PR TITLE
fix(linux): cancel the X11 event loop on unregister

### DIFF
--- a/hotkey_linux.c
+++ b/hotkey_linux.c
@@ -6,25 +6,26 @@
 
 //go:build linux
 
-#include <stdint.h>
-#include <stdio.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <stdint.h>
+#include <string.h> // memset
 
 extern void hotkeyDown(uintptr_t hkhandle);
 extern void hotkeyUp(uintptr_t hkhandle);
 
 int displayTest() {
-	Display* d = NULL;
-	for (int i = 0; i < 42; i++) {
-		d = XOpenDisplay(0);
-		if (d == NULL) continue;
-		break;
-	}
-	if (d == NULL) {
-		return -1;
-	}
-	return 0;
+  Display *d = NULL;
+  for (int i = 0; i < 42; i++) {
+    d = XOpenDisplay(0);
+    if (d == NULL)
+      continue;
+    break;
+  }
+  if (d == NULL) {
+    return -1;
+  }
+  return 0;
 }
 
 // FIXME: handle bad access properly.
@@ -38,48 +39,95 @@ int displayTest() {
 //         pErr->minor_code );
 //     if( pErr->request_code == 33 ){  // 33 (X_GrabKey)
 //         if( pErr->error_code == BadAccess ){
-//             printf("ERROR: key combination already grabbed by another client.\n");
-//             return 0;
+//             printf("ERROR: key combination already grabbed by another
+//             client.\n"); return 0;
 //         }
 //     }
 //     return 0;
 // }
 
-// waitHotkey blocks until the hotkey is triggered.
-// this function crashes the program if the hotkey already grabbed by others.
+Display *openDisplay() {
+  Display *d = NULL;
+  for (int i = 0; i < 42; i++) {
+    d = XOpenDisplay(0);
+    if (d == NULL)
+      continue;
+    break;
+  }
+  return d;
+}
+
+// Creates an invisible window, which can receive ClientMessage events. On
+// hotkey cancel a ClientMessageEvent is generated on the window. The event is
+// catched and the event loop terminates. x: 0 y: 0 w: 1 h: 1 border_width: 1
+// depth: 0
+// class: InputOnly (window will not be drawn)
+// visual: default visual of display
+// no attributes will be set (0, &attr)
+Window createInvisWindow(Display *d) {
+  XSetWindowAttributes attr;
+  return XCreateWindow(d, DefaultRootWindow(d), 0, 0, 1, 1, 0, 0, InputOnly,
+                       DefaultVisual(d, 0), 0, &attr);
+}
+
+// Sends a custom ClientMessage of type (Atom) "go_hotkey_cancel_hotkey"
+// Passed value 'True' of XInternAtom creates the Atom, if it does not exist yet
+void sendCancel(Display *d, Window window) {
+  Atom atom = XInternAtom(d, "golangdesign_hotkey_cancel_hotkey", True);
+  XClientMessageEvent clientEvent;
+  memset(&clientEvent, 0, sizeof(clientEvent));
+  clientEvent.type = ClientMessage;
+  clientEvent.send_event = True;
+  clientEvent.display = d;
+  clientEvent.window = window;
+  clientEvent.message_type = atom;
+  clientEvent.format = 8;
+
+  XEvent event;
+  event.type = ClientMessage;
+  event.xclient = clientEvent;
+  XSendEvent(d, window, False, 0, &event);
+  XFlush(d);
+}
+
+// Closes the connection and destroys the invisible 'cancel' window
+void cleanupConnection(Display *d, Window w) {
+  XDestroyWindow(d, w);
+  XCloseDisplay(d);
+}
+
+// waitHotkey blocks until the hotkey is triggered or canceled.
 //
 // mods points to nmods modifier masks: the same hotkey is grabbed once per
 // mask so that it still fires while NumLock/CapsLock are active (those locks
 // add bits to the event state that an exact-mask grab would not match).
-int waitHotkey(uintptr_t hkhandle, unsigned int* mods, int nmods, int key) {
-	Display* d = NULL;
-	for (int i = 0; i < 42; i++) {
-		d = XOpenDisplay(0);
-		if (d == NULL) continue;
-		break;
-	}
-	if (d == NULL) {
-		return -1;
-	}
-	int keycode = XKeysymToKeycode(d, key);
-	for (int i = 0; i < nmods; i++) {
-		XGrabKey(d, keycode, mods[i], DefaultRootWindow(d), False, GrabModeAsync, GrabModeAsync);
-	}
-	XSelectInput(d, DefaultRootWindow(d), KeyPressMask);
-	XEvent ev;
-	while(1) {
-		XNextEvent(d, &ev);
-		switch(ev.type) {
-		case KeyPress:
-			hotkeyDown(hkhandle);
-			continue;
-		case KeyRelease:
-			hotkeyUp(hkhandle);
-			for (int i = 0; i < nmods; i++) {
-				XUngrabKey(d, keycode, mods[i], DefaultRootWindow(d));
-			}
-			XCloseDisplay(d);
-			return 0;
-		}
-	}
+//
+// d is an owned display connection and w an invisible window on it; sending w
+// a ClientMessage (see sendCancel) breaks the loop out of XNextEvent so an
+// unregister can take effect without waiting for the next keypress.
+int waitHotkey(uintptr_t hkhandle, unsigned int *mods, int nmods, int key,
+               Display *d, Window w) {
+  int keycode = XKeysymToKeycode(d, key);
+  for (int i = 0; i < nmods; i++) {
+    XGrabKey(d, keycode, mods[i], DefaultRootWindow(d), False, GrabModeAsync,
+             GrabModeAsync);
+  }
+  XSelectInput(d, DefaultRootWindow(d), KeyPressMask);
+  XEvent ev;
+  while (1) {
+    XNextEvent(d, &ev);
+    switch (ev.type) {
+    case KeyPress:
+      hotkeyDown(hkhandle);
+      continue;
+    case KeyRelease:
+      hotkeyUp(hkhandle);
+      for (int i = 0; i < nmods; i++) {
+        XUngrabKey(d, keycode, mods[i], DefaultRootWindow(d));
+      }
+      return 0;
+    case ClientMessage:
+      return 0;
+    }
+  }
 }

--- a/hotkey_linux.go
+++ b/hotkey_linux.go
@@ -12,9 +12,14 @@ package hotkey
 #cgo LDFLAGS: -lX11
 
 #include <stdint.h>
+#include <X11/Xlib.h>
 
 int displayTest();
-int waitHotkey(uintptr_t hkhandle, unsigned int* mods, int nmods, int key);
+Display *openDisplay();
+Window createInvisWindow(Display *d);
+void sendCancel(Display *d, Window window);
+void cleanupConnection(Display *d, Window window);
+int waitHotkey(uintptr_t hkhandle, unsigned int* mods, int nmods, int key, Display *d, Window w);
 */
 import "C"
 import (
@@ -50,6 +55,8 @@ type platformHotkey struct {
 	ctx        context.Context
 	cancel     context.CancelFunc
 	canceled   chan struct{}
+	display    *C.Display
+	window     C.Window
 }
 
 // Nothing needs to do for register
@@ -76,6 +83,9 @@ func (hk *Hotkey) unregister() error {
 		return errors.New("hotkey is not registered.")
 	}
 	hk.cancel()
+	if hk.display != nil {
+		C.sendCancel(hk.display, hk.window)
+	}
 	hk.registered = false
 	<-hk.canceled
 	return nil
@@ -88,12 +98,16 @@ func (hk *Hotkey) handle() {
 	defer runtime.UnlockOSThread()
 	// KNOWN ISSUE: if a hotkey is grabbed by others, C side will crash the program
 
+	hk.display = C.openDisplay()
+	hk.window = C.createInvisWindow(hk.display)
+
 	var mod Modifier
 	for _, m := range hk.mods {
 		mod = mod | m
 	}
 	h := cgo.NewHandle(hk)
 	defer h.Delete()
+	defer hk.cleanConnection()
 
 	// Grab the hotkey once per NumLock/CapsLock state so it fires
 	// regardless of those locks (see lockVariants).
@@ -109,9 +123,14 @@ func (hk *Hotkey) handle() {
 			close(hk.canceled)
 			return
 		default:
-			_ = C.waitHotkey(C.uintptr_t(h), &cmods[0], C.int(len(cmods)), C.int(hk.key))
+			_ = C.waitHotkey(C.uintptr_t(h), &cmods[0], C.int(len(cmods)), C.int(hk.key), hk.display, hk.window)
 		}
 	}
+}
+
+func (hk *Hotkey) cleanConnection() {
+	C.cleanupConnection(hk.display, hk.window)
+	hk.display = nil
 }
 
 // X11 lock modifier masks (see /usr/include/X11/X.h).

--- a/hotkey_linux_test.go
+++ b/hotkey_linux_test.go
@@ -59,3 +59,26 @@ func TestHotkey(t *testing.T) {
 		}
 	}
 }
+
+func TestHotkey_Unregister(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	hk := hotkey.New([]hotkey.Modifier{hotkey.ModCtrl, hotkey.Mod2, hotkey.Mod4}, hotkey.KeyA)
+	if err := hk.Register(); err != nil {
+		t.Errorf("failed to register hotkey: %v", err)
+		return
+	}
+	if err := hk.Unregister(); err != nil {
+		t.Errorf("failed to unregister hotkey: %v", err)
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-hk.Keydown():
+			t.Fatalf("hotkey should not be registered but actually triggered.")
+		}
+	}
+}


### PR DESCRIPTION
Previously the X11 backend blocked in `XNextEvent` until the hotkey was pressed, so `Unregister()` could not interrupt a waiting event loop — the hotkey was only released after it was next triggered, and `Keydown` could block forever (#15, #33).

This creates an invisible `InputOnly` window per hotkey and, on unregister, sends it a custom `ClientMessage` that breaks `waitHotkey` out of `XNextEvent` so the loop observes the canceled context and returns. Adds `TestHotkey_Unregister`.

**Adapted from #16 by @data-niklas** — adopted onto current `main` with the commit message in this repo's style. The earlier SIGSEGV the maintainer hit (nil display in `sendCancel`) is guarded; the immediate register→unregister path now exits via the `ctx.Done()` branch of the event loop.

Fixes #15. One fix, one PR.