### PR TITLE
fix(linux): return an error when the hotkey is already grabbed

### DIFF
--- a/hotkey_x11.c
+++ b/hotkey_x11.c
@@ -96,23 +96,48 @@ void cleanupConnection(Display *d, Window w) {
   XCloseDisplay(d);
 }
 
-// waitHotkey blocks until the hotkey is triggered or canceled.
-//
-// mods points to nmods modifier masks: the same hotkey is grabbed once per
-// mask so that it still fires while NumLock/CapsLock are active (those locks
-// add bits to the event state that an exact-mask grab would not match).
-//
-// d is an owned display connection and w an invisible window on it; sending w
-// a ClientMessage (see sendCancel) breaks the loop out of XNextEvent so an
-// unregister can take effect without waiting for the next keypress.
-int waitHotkey(uintptr_t hkhandle, unsigned int *mods, int nmods, int key,
-               Display *d, Window w) {
+// lastGrabError records the X error code raised during the most recent
+// grabHotkey call (0 if none). grabHotkey is serialized on the Go side, so a
+// single global slot is sufficient.
+static int lastGrabError = 0;
+
+int grabErrorHandler(Display *d, XErrorEvent *e) {
+  lastGrabError = e->error_code;
+  return 0;
+}
+
+// grabHotkey grabs key on display d once per modifier mask in mods (the
+// NumLock/CapsLock variants). It installs a temporary error handler and
+// XSyncs so that a BadAccess -- the combination is already grabbed by another
+// client -- is reported synchronously instead of terminating the program via
+// Xlib's default handler. Returns 0 on success, 1 if the combination is
+// unavailable. Callers must serialize this (it uses a process-global error
+// slot and swaps the process-global X error handler).
+int grabHotkey(Display *d, unsigned int *mods, int nmods, int key) {
+  lastGrabError = 0;
   int keycode = XKeysymToKeycode(d, key);
+  XErrorHandler old = XSetErrorHandler(grabErrorHandler);
   for (int i = 0; i < nmods; i++) {
     XGrabKey(d, keycode, mods[i], DefaultRootWindow(d), False, GrabModeAsync,
              GrabModeAsync);
   }
+  XSync(d, False); // force the server to deliver any grab error to our handler
+  XSetErrorHandler(old);
+  if (lastGrabError == BadAccess) {
+    for (int i = 0; i < nmods; i++) {
+      XUngrabKey(d, keycode, mods[i], DefaultRootWindow(d));
+    }
+    return 1;
+  }
   XSelectInput(d, DefaultRootWindow(d), KeyPressMask);
+  return 0;
+}
+
+// waitHotkey delivers key events on display d until a cancel ClientMessage
+// (see sendCancel) breaks the loop out of XNextEvent so an unregister can take
+// effect without waiting for the next keypress. The grab is established once
+// by grabHotkey and held until cleanupConnection.
+void waitHotkey(uintptr_t hkhandle, Display *d) {
   XEvent ev;
   while (1) {
     XNextEvent(d, &ev);
@@ -122,12 +147,9 @@ int waitHotkey(uintptr_t hkhandle, unsigned int *mods, int nmods, int key,
       continue;
     case KeyRelease:
       hotkeyUp(hkhandle);
-      for (int i = 0; i < nmods; i++) {
-        XUngrabKey(d, keycode, mods[i], DefaultRootWindow(d));
-      }
-      return 0;
+      continue;
     case ClientMessage:
-      return 0;
+      return;
     }
   }
 }

--- a/hotkey_x11.go
+++ b/hotkey_x11.go
@@ -117,7 +117,6 @@ func (hk *Hotkey) register() error {
 	return nil
 }
 
-// Nothing needs to do for unregister
 func (hk *Hotkey) unregister() error {
 	hk.mu.Lock()
 	defer hk.mu.Unlock()
@@ -125,11 +124,14 @@ func (hk *Hotkey) unregister() error {
 		return errors.New("hotkey is not registered.")
 	}
 	hk.cancel()
-	if hk.display != nil {
-		C.sendCancel(hk.display, hk.window)
-	}
-	hk.registered = false
+	C.sendCancel(hk.display, hk.window)
 	<-hk.canceled
+	// Tear down the connection only after the event loop has returned, so the
+	// XDestroyWindow/XCloseDisplay cannot race the sendCancel above (which
+	// would destroy the window out from under the in-flight XSendEvent).
+	C.cleanupConnection(hk.display, hk.window)
+	hk.display = nil
+	hk.registered = false
 	return nil
 }
 
@@ -141,7 +143,6 @@ func (hk *Hotkey) handle() {
 
 	h := cgo.NewHandle(hk)
 	defer h.Delete()
-	defer hk.cleanConnection()
 
 	for {
 		select {
@@ -152,11 +153,6 @@ func (hk *Hotkey) handle() {
 			C.waitHotkey(C.uintptr_t(h), hk.display)
 		}
 	}
-}
-
-func (hk *Hotkey) cleanConnection() {
-	C.cleanupConnection(hk.display, hk.window)
-	hk.display = nil
 }
 
 // X11 lock modifier masks (see /usr/include/X11/X.h).

--- a/hotkey_x11.go
+++ b/hotkey_x11.go
@@ -47,6 +47,11 @@ Then this package should be ready to use.
 `
 
 func init() {
+	// The X11 display is touched from multiple threads (register opens it and
+	// grabs, the per-hotkey event loop blocks in XNextEvent, and unregister
+	// sends the cancel event), so Xlib must be made thread-safe before the
+	// first Xlib call.
+	C.XInitThreads()
 	if C.displayTest() != 0 {
 		panic(errmsg)
 	}

--- a/hotkey_x11.go
+++ b/hotkey_x11.go
@@ -21,7 +21,8 @@ Display *openDisplay();
 Window createInvisWindow(Display *d);
 void sendCancel(Display *d, Window window);
 void cleanupConnection(Display *d, Window window);
-int waitHotkey(uintptr_t hkhandle, unsigned int* mods, int nmods, int key, Display *d, Window w);
+int grabHotkey(Display *d, unsigned int* mods, int nmods, int key);
+void waitHotkey(uintptr_t hkhandle, Display *d);
 */
 import "C"
 import (
@@ -61,17 +62,51 @@ type platformHotkey struct {
 	window     C.Window
 }
 
-// Nothing needs to do for register
+// grabMu serializes the grab in register across hotkeys, because the C side
+// uses a process-global error slot and swaps the process-global X error
+// handler while probing for a conflict.
+var grabMu sync.Mutex
+
 func (hk *Hotkey) register() error {
 	hk.mu.Lock()
+	defer hk.mu.Unlock()
 	if hk.registered {
-		hk.mu.Unlock()
 		return errors.New("hotkey already registered.")
 	}
+
+	var mod Modifier
+	for _, m := range hk.mods {
+		mod = mod | m
+	}
+	// Grab the hotkey once per NumLock/CapsLock state so it fires regardless
+	// of those locks (see lockVariants).
+	variants := lockVariants(mod)
+	cmods := make([]C.uint, len(variants))
+	for i, v := range variants {
+		cmods[i] = C.uint(v)
+	}
+
+	display := C.openDisplay()
+	if display == nil {
+		return errors.New("hotkey: failed to open the X11 display.")
+	}
+	window := C.createInvisWindow(display)
+
+	// Grab synchronously so a conflict surfaces here as an error instead of
+	// crashing the program later via Xlib's default error handler.
+	grabMu.Lock()
+	rc := C.grabHotkey(display, &cmods[0], C.int(len(cmods)), C.int(hk.key))
+	grabMu.Unlock()
+	if rc != 0 {
+		C.cleanupConnection(display, window)
+		return errors.New("hotkey: the key combination is already registered by another application.")
+	}
+
+	hk.display = display
+	hk.window = window
 	hk.registered = true
 	hk.ctx, hk.cancel = context.WithCancel(context.Background())
 	hk.canceled = make(chan struct{})
-	hk.mu.Unlock()
 
 	go hk.handle()
 	return nil
@@ -93,31 +128,15 @@ func (hk *Hotkey) unregister() error {
 	return nil
 }
 
-// handle registers an application global hotkey to the system,
-// and returns a channel that will signal if the hotkey is triggered.
+// handle delivers events for an already-registered (and grabbed) hotkey until
+// it is unregistered.
 func (hk *Hotkey) handle() {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
-	// KNOWN ISSUE: if a hotkey is grabbed by others, C side will crash the program
 
-	hk.display = C.openDisplay()
-	hk.window = C.createInvisWindow(hk.display)
-
-	var mod Modifier
-	for _, m := range hk.mods {
-		mod = mod | m
-	}
 	h := cgo.NewHandle(hk)
 	defer h.Delete()
 	defer hk.cleanConnection()
-
-	// Grab the hotkey once per NumLock/CapsLock state so it fires
-	// regardless of those locks (see lockVariants).
-	variants := lockVariants(mod)
-	cmods := make([]C.uint, len(variants))
-	for i, v := range variants {
-		cmods[i] = C.uint(v)
-	}
 
 	for {
 		select {
@@ -125,7 +144,7 @@ func (hk *Hotkey) handle() {
 			close(hk.canceled)
 			return
 		default:
-			_ = C.waitHotkey(C.uintptr_t(h), &cmods[0], C.int(len(cmods)), C.int(hk.key), hk.display, hk.window)
+			C.waitHotkey(C.uintptr_t(h), hk.display)
 		}
 	}
 }

--- a/hotkey_x11_test.go
+++ b/hotkey_x11_test.go
@@ -37,6 +37,23 @@ func TestKeycodesAreDistinct(t *testing.T) {
 	}
 }
 
+// TestRegisterConflict verifies that registering a key combination already
+// grabbed by another X client returns an error instead of crashing the
+// process via Xlib's default BadAccess handler (issue #11).
+func TestRegisterConflict(t *testing.T) {
+	hk1 := hotkey.New([]hotkey.Modifier{hotkey.ModCtrl, hotkey.ModShift}, hotkey.KeyF8)
+	if err := hk1.Register(); err != nil {
+		t.Fatalf("first registration failed: %v", err)
+	}
+	defer hk1.Unregister()
+
+	hk2 := hotkey.New([]hotkey.Modifier{hotkey.ModCtrl, hotkey.ModShift}, hotkey.KeyF8)
+	if err := hk2.Register(); err == nil {
+		hk2.Unregister()
+		t.Fatal("registering an already-grabbed hotkey should return an error, got nil")
+	}
+}
+
 // TestHotkey should always run success.
 // This is a test to run and for manually testing, registered combination:
 // Ctrl+Alt+A (Ctrl+Mod2+Mod4+A on Linux)
@@ -50,6 +67,9 @@ func TestHotkey(t *testing.T) {
 		t.Errorf("failed to register hotkey: %v", err)
 		return
 	}
+	// Release the grab on return; otherwise it would leak and conflict with
+	// later tests that register the same combination.
+	defer hk.Unregister()
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
Registering a key combination already grabbed by another X client raised `BadAccess` from `XGrabKey`, which Xlib's default handler turns into a process exit — so the program **crashed** instead of reporting a failure (#11).

Per the discussion in #12, the bar was: surface the failure **synchronously at `Register()`**, with **no new public API**. This does that:

- The grab moves into `register()` and runs synchronously: a temporary X error handler is installed, every NumLock/CapsLock mask variant is grabbed, `XSync` forces the server to report errors, and `Register()` returns a normal `error` on `BadAccess`. No public API.
- The event loop (`handle`/`waitHotkey`) no longer opens the display or grabs — it just delivers events on the display `register()` opened, and still cancels via the `ClientMessage` from #38.
- Serialized by `grabMu` because the C side uses a global error slot and swaps the process-global handler.

Testable without faking input: `TestRegisterConflict` registers the same combination twice in-process (two X connections) and asserts the second `Register()` returns an error rather than crashing. Also fixes a grab leak in `TestHotkey`.

Fixes #11.