### PR TITLE
all: normalize Register/Unregister error messages across platforms

### DIFF
--- a/hotkey.go
+++ b/hotkey.go
@@ -64,8 +64,17 @@
 package hotkey
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
+)
+
+// Errors reported by Register and Unregister. They are shared across all
+// platforms so the message is identical regardless of the operating system.
+var (
+	errAlreadyRegistered = errors.New("hotkey: already registered")
+	errNotRegistered     = errors.New("hotkey: not registered")
+	errRegisterFailed    = errors.New("hotkey: failed to register, the combination might already be taken by another application")
 )
 
 // Event represents a hotkey event

--- a/hotkey_darwin.go
+++ b/hotkey_darwin.go
@@ -38,7 +38,7 @@ func (hk *Hotkey) register() error {
 	hk.mu.Lock()
 	defer hk.mu.Unlock()
 	if hk.registered {
-		return errors.New("hotkey already registered")
+		return errAlreadyRegistered
 	}
 
 	// Note: we use handle number as hotkey id in the C side.
@@ -53,7 +53,7 @@ func (hk *Hotkey) register() error {
 
 	ret := C.registerHotKey(C.int(mod), C.int(hk.key), C.uintptr_t(h), &hk.hkref)
 	if ret == C.int(-1) {
-		return errors.New("failed to register the hotkey")
+		return errRegisterFailed
 	}
 
 	hk.registered = true
@@ -64,12 +64,12 @@ func (hk *Hotkey) unregister() error {
 	hk.mu.Lock()
 	defer hk.mu.Unlock()
 	if !hk.registered {
-		return errors.New("hotkey is not registered")
+		return errNotRegistered
 	}
 
 	ret := C.unregisterHotKey(hk.hkref)
 	if ret == C.int(-1) {
-		return errors.New("failed to unregister the current hotkey")
+		return errors.New("hotkey: failed to unregister")
 	}
 	hk.registered = false
 	return nil

--- a/hotkey_windows.go
+++ b/hotkey_windows.go
@@ -9,7 +9,7 @@
 package hotkey
 
 import (
-	"errors"
+	"fmt"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -35,7 +35,7 @@ func (hk *Hotkey) register() error {
 	hk.mu.Lock()
 	if hk.registered {
 		hk.mu.Unlock()
-		return errors.New("hotkey already registered")
+		return errAlreadyRegistered
 	}
 
 	mod := uint8(0)
@@ -61,7 +61,7 @@ func (hk *Hotkey) register() error {
 	if !ok {
 		close(hk.canceled)
 		hk.mu.Unlock()
-		return err
+		return fmt.Errorf("%w: %v", errRegisterFailed, err)
 	}
 	hk.registered = true
 	hk.mu.Unlock()
@@ -73,7 +73,7 @@ func (hk *Hotkey) unregister() error {
 	hk.mu.Lock()
 	defer hk.mu.Unlock()
 	if !hk.registered {
-		return errors.New("hotkey is not registered")
+		return errNotRegistered
 	}
 
 	done := make(chan struct{})

--- a/hotkey_x11.go
+++ b/hotkey_x11.go
@@ -76,7 +76,7 @@ func (hk *Hotkey) register() error {
 	hk.mu.Lock()
 	defer hk.mu.Unlock()
 	if hk.registered {
-		return errors.New("hotkey already registered.")
+		return errAlreadyRegistered
 	}
 
 	var mod Modifier
@@ -93,7 +93,7 @@ func (hk *Hotkey) register() error {
 
 	display := C.openDisplay()
 	if display == nil {
-		return errors.New("hotkey: failed to open the X11 display.")
+		return errors.New("hotkey: failed to open the X11 display")
 	}
 	window := C.createInvisWindow(display)
 
@@ -104,7 +104,7 @@ func (hk *Hotkey) register() error {
 	grabMu.Unlock()
 	if rc != 0 {
 		C.cleanupConnection(display, window)
-		return errors.New("hotkey: the key combination is already registered by another application.")
+		return errRegisterFailed
 	}
 
 	hk.display = display
@@ -121,7 +121,7 @@ func (hk *Hotkey) unregister() error {
 	hk.mu.Lock()
 	defer hk.mu.Unlock()
 	if !hk.registered {
-		return errors.New("hotkey is not registered.")
+		return errNotRegistered
 	}
 	hk.cancel()
 	C.sendCancel(hk.display, hk.window)


### PR DESCRIPTION
The three OS backends reported registration failures with different, inconsistently styled strings — trailing periods on Linux, terse text on macOS (`failed to register the hotkey`), and a raw syscall errno on Windows.

This defines shared error values in the platform-agnostic `hotkey.go` so the common cases read identically on every OS:
- `hotkey: already registered`
- `hotkey: not registered`
- `hotkey: failed to register, the combination might already be taken by another application`

Windows wraps the underlying errno with `%w` so the detail is preserved (and `errors.Is`-able). Linux keeps its distinct `failed to open the X11 display` message; macOS keeps a distinct `failed to unregister` for its OS-level unregister failure. No behavior change — only message text.