### PR TITLE
all: widen Key to uint32 on every platform

### DIFF
--- a/hotkey_darwin.go
+++ b/hotkey_darwin.go
@@ -101,7 +101,7 @@ const (
 
 // Key represents a key.
 // See: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/Headers/Events.h
-type Key uint8
+type Key uint32
 
 // All kinds of keys
 const (

--- a/hotkey_nocgo.go
+++ b/hotkey_nocgo.go
@@ -14,7 +14,7 @@ type platformHotkey struct{}
 type Modifier uint32
 
 // Key represents a key.
-type Key uint8
+type Key uint32
 
 func (hk *Hotkey) register() error {
 	panic("hotkey: cannot use when CGO_ENABLED=0")

--- a/hotkey_windows.go
+++ b/hotkey_windows.go
@@ -150,7 +150,7 @@ const (
 
 // Key represents a key.
 // https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
-type Key uint16
+type Key uint32
 
 // All kinds of Keys
 const (

--- a/hotkey_x11.go
+++ b/hotkey_x11.go
@@ -209,7 +209,7 @@ const (
 
 // Key represents a key.
 // See /usr/include/X11/keysymdef.h
-type Key uint16
+type Key uint32
 
 // All kinds of keys
 const (


### PR DESCRIPTION
Foundational change for media-key support (#28). Media keys need wider codes than the current `Key` types allow:
- X11 `XF86*` keysyms (e.g. `XF86AudioPlay` = `0x1008FF14`) overflow `uint16`.
- macOS needs more than `uint8` to disambiguate media keys from Carbon keycodes.

Unifies `Key` as `uint32` on all platforms (was `uint8` on darwin/nocgo, `uint16` on linux/windows). Uniform width also removes a longstanding per-platform divergence.

**Source-compat note:** code doing an explicit narrowing cast like `uint16(key)` needs updating. `hotkey.KeyA`, `hotkey.Key(0x15)`, and comparisons are unaffected. Verified by build + existing tests on all platforms.

Foundation for the Linux/Windows media constants and the macOS CGEventTap backend that follow.