### PR TITLE
all: add media key constants for Linux (X11) and Windows

### DIFF
--- a/hotkey_windows.go
+++ b/hotkey_windows.go
@@ -223,3 +223,16 @@ const (
 	KeyF19 Key = 0x82
 	KeyF20 Key = 0x83
 )
+
+// Media keys. These are Windows virtual-key codes
+// (https://learn.microsoft.com/windows/win32/inputdev/virtual-key-codes) and
+// are registered through the same RegisterHotKey path as any other key.
+const (
+	KeyMediaPlayPause Key = 0xB3 // VK_MEDIA_PLAY_PAUSE
+	KeyMediaNext      Key = 0xB0 // VK_MEDIA_NEXT_TRACK
+	KeyMediaPrev      Key = 0xB1 // VK_MEDIA_PREV_TRACK
+	KeyMediaStop      Key = 0xB2 // VK_MEDIA_STOP
+	KeyVolumeUp       Key = 0xAF // VK_VOLUME_UP
+	KeyVolumeDown     Key = 0xAE // VK_VOLUME_DOWN
+	KeyVolumeMute     Key = 0xAD // VK_VOLUME_MUTE
+)

--- a/hotkey_x11.go
+++ b/hotkey_x11.go
@@ -282,3 +282,16 @@ const (
 	KeyF19 Key = 0xffd0
 	KeyF20 Key = 0xffd1
 )
+
+// Media keys. These are X11 XF86 keysyms (see
+// /usr/include/X11/XF86keysym.h) and are grabbed through the same path as
+// any other key.
+const (
+	KeyMediaPlayPause Key = 0x1008FF14 // XF86AudioPlay
+	KeyMediaNext      Key = 0x1008FF17 // XF86AudioNext
+	KeyMediaPrev      Key = 0x1008FF16 // XF86AudioPrev
+	KeyMediaStop      Key = 0x1008FF15 // XF86AudioStop
+	KeyVolumeUp       Key = 0x1008FF13 // XF86AudioRaiseVolume
+	KeyVolumeDown     Key = 0x1008FF11 // XF86AudioLowerVolume
+	KeyVolumeMute     Key = 0x1008FF12 // XF86AudioMute
+)


### PR DESCRIPTION
Part of media-key support (#28), building on the `Key`→`uint32` widening (#42).

Adds unified media/volume constants — `KeyMediaPlayPause`, `KeyMediaNext`, `KeyMediaPrev`, `KeyMediaStop`, `KeyVolumeUp`, `KeyVolumeDown`, `KeyVolumeMute` — with the same names on both platforms:
- **Linux**: `XF86*` keysyms (e.g. `XF86AudioPlay` = `0x1008FF14`).
- **Windows**: `VK_MEDIA_*` / `VK_VOLUME_*` codes.

Both flow through the **existing** `XGrabKey` / `RegisterHotKey` paths — no routing changes — so usage is just:
```go
hk := hotkey.New(nil, hotkey.KeyMediaPlayPause)
```

macOS uses a different mechanism (`NSSystemDefined` / `CGEventTap`) for these keys and gets the same constant names in a follow-up PR with its own backend. Verified by build on all platforms + existing tests.

Note: media-key *behavior* is not CI-verifiable on any platform (Xvfb has no media keys, Windows/macOS behavior never ran in CI) — this PR is compile-and-existing-tests verified; the registration path is the same one already exercised by the normal-key tests.