### PR TITLE
feat(darwin): media keys via CGEventTap (hybrid)

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module golang.design/x/hotkey/examples
 
-go 1.19
+go 1.24
 
 require (
 	fyne.io/fyne/v2 v2.3.0

--- a/examples/media/main.go
+++ b/examples/media/main.go
@@ -1,0 +1,81 @@
+// Copyright 2026 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+
+// Command media demonstrates registering media keys (play/pause, next,
+// previous, volume) and reporting their press/release events.
+//
+// Run it:
+//
+//	go run golang.design/x/hotkey/examples/media
+//
+// then press the media keys on your keyboard. Press Ctrl+C to quit.
+//
+// Platform notes:
+//
+//   - Linux (X11) and Windows: media keys work with no special permission.
+//
+//   - macOS: media keys are captured with a CGEventTap, which requires
+//     Accessibility / Input Monitoring permission. Because `go run` builds a
+//     throwaway binary whose path changes every run, the permission grant will
+//     not stick; build a stable binary instead and grant *that* (or grant your
+//     terminal) in System Settings → Privacy & Security → Accessibility:
+//
+//     go build -o mediatest golang.design/x/hotkey/examples/media
+//     ./mediatest   # then approve the Accessibility prompt and re-run
+//
+//     If permission is missing, Register returns an error (it does not crash).
+//     macOS has no media-stop key, so KeyMediaStop returns an error there.
+package main
+
+import (
+	"log"
+
+	"golang.design/x/hotkey"
+	"golang.design/x/hotkey/mainthread"
+)
+
+func main() { mainthread.Init(fn) } // Required on macOS for the event loop.
+
+func fn() {
+	// Media keys are global and take no modifiers.
+	media := []struct {
+		name string
+		key  hotkey.Key
+	}{
+		{"play/pause", hotkey.KeyMediaPlayPause},
+		{"next", hotkey.KeyMediaNext},
+		{"previous", hotkey.KeyMediaPrev},
+		{"volume up", hotkey.KeyVolumeUp},
+		{"volume down", hotkey.KeyVolumeDown},
+		{"mute", hotkey.KeyVolumeMute},
+	}
+
+	registered := 0
+	for _, m := range media {
+		hk := hotkey.New(nil, m.key)
+		if err := hk.Register(); err != nil {
+			log.Printf("skip %-12s: %v", m.name, err)
+			continue
+		}
+		registered++
+		log.Printf("registered: %s", m.name)
+		go listen(m.name, hk)
+	}
+
+	if registered == 0 {
+		log.Fatal("no media hotkey could be registered (on macOS, grant Accessibility permission)")
+	}
+
+	log.Println("press a media key to see events; Ctrl+C to quit")
+	select {} // run until interrupted
+}
+
+func listen(name string, hk *hotkey.Hotkey) {
+	for {
+		<-hk.Keydown()
+		log.Printf("%-12s down", name)
+		<-hk.Keyup()
+		log.Printf("%-12s up", name)
+	}
+}

--- a/hotkey_darwin.go
+++ b/hotkey_darwin.go
@@ -10,7 +10,7 @@ package hotkey
 
 /*
 #cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Cocoa -framework Carbon
+#cgo LDFLAGS: -framework Cocoa -framework Carbon -framework CoreGraphics
 #include <stdint.h>
 #import <Cocoa/Cocoa.h>
 #import <Carbon/Carbon.h>
@@ -19,12 +19,18 @@ extern void keydownCallback(uintptr_t handle);
 extern void keyupCallback(uintptr_t handle);
 int registerHotKey(int mod, int key, uintptr_t handle, EventHotKeyRef* ref);
 int unregisterHotKey(EventHotKeyRef ref);
+
+// Media keys are not delivered through Carbon hot keys; they arrive as
+// NSSystemDefined events, captured here with a CGEventTap.
+void* registerMediaTap(uintptr_t handle, int nxKeyCode);
+void unregisterMediaTap(void* tap);
 */
 import "C"
 import (
 	"errors"
 	"runtime/cgo"
 	"sync"
+	"unsafe"
 )
 
 // Hotkey is a combination of modifiers and key to trigger an event
@@ -32,6 +38,10 @@ type platformHotkey struct {
 	mu         sync.Mutex
 	registered bool
 	hkref      C.EventHotKeyRef
+
+	// media-key registrations use a CGEventTap instead of a Carbon hot key.
+	mediaTap    unsafe.Pointer
+	mediaHandle cgo.Handle
 }
 
 func (hk *Hotkey) register() error {
@@ -39,6 +49,10 @@ func (hk *Hotkey) register() error {
 	defer hk.mu.Unlock()
 	if hk.registered {
 		return errAlreadyRegistered
+	}
+
+	if hk.key&mediaKeyBit != 0 {
+		return hk.registerMedia()
 	}
 
 	// Note: we use handle number as hotkey id in the C side.
@@ -60,11 +74,41 @@ func (hk *Hotkey) register() error {
 	return nil
 }
 
+// registerMedia registers a media key via a CGEventTap. Must be called with
+// hk.mu held.
+func (hk *Hotkey) registerMedia() error {
+	if hk.key == KeyMediaStop {
+		// There is no NX_KEYTYPE for media stop on macOS.
+		return errors.New("hotkey: media stop is not available on macOS")
+	}
+	nx := C.int(hk.key &^ mediaKeyBit)
+	h := cgo.NewHandle(hk)
+	tap := C.registerMediaTap(C.uintptr_t(h), nx)
+	if tap == nil {
+		h.Delete()
+		// CGEventTapCreate returns NULL without Accessibility/Input Monitoring
+		// permission.
+		return errors.New("hotkey: failed to register media key, grant the application Accessibility (Input Monitoring) permission")
+	}
+	hk.mediaTap = tap
+	hk.mediaHandle = h
+	hk.registered = true
+	return nil
+}
+
 func (hk *Hotkey) unregister() error {
 	hk.mu.Lock()
 	defer hk.mu.Unlock()
 	if !hk.registered {
 		return errNotRegistered
+	}
+
+	if hk.mediaTap != nil {
+		C.unregisterMediaTap(hk.mediaTap)
+		hk.mediaTap = nil
+		hk.mediaHandle.Delete()
+		hk.registered = false
+		return nil
 	}
 
 	ret := C.unregisterHotKey(hk.hkref)
@@ -173,4 +217,21 @@ const (
 	KeyF18 Key = 0x4F
 	KeyF19 Key = 0x50
 	KeyF20 Key = 0x5A
+)
+
+// mediaKeyBit marks a Key as a macOS media key, encoded as an NX_KEYTYPE_*
+// code (see <IOKit/hidsystem/ev_keymap.h>) rather than a Carbon virtual
+// keycode. register() detects the bit and routes such keys to a CGEventTap.
+const mediaKeyBit Key = 1 << 16
+
+// Media keys. The low bits are NX_KEYTYPE_* codes. KeyMediaStop has no NX
+// equivalent on macOS; registering it returns an error.
+const (
+	KeyMediaPlayPause Key = mediaKeyBit | 16     // NX_KEYTYPE_PLAY
+	KeyMediaNext      Key = mediaKeyBit | 17     // NX_KEYTYPE_NEXT
+	KeyMediaPrev      Key = mediaKeyBit | 18     // NX_KEYTYPE_PREVIOUS
+	KeyMediaStop      Key = mediaKeyBit | 0xffff // unsupported on macOS
+	KeyVolumeUp       Key = mediaKeyBit | 0      // NX_KEYTYPE_SOUND_UP
+	KeyVolumeDown     Key = mediaKeyBit | 1      // NX_KEYTYPE_SOUND_DOWN
+	KeyVolumeMute     Key = mediaKeyBit | 7      // NX_KEYTYPE_MUTE
 )

--- a/hotkey_darwin.go
+++ b/hotkey_darwin.go
@@ -10,7 +10,7 @@ package hotkey
 
 /*
 #cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Cocoa -framework Carbon -framework CoreGraphics
+#cgo LDFLAGS: -framework Cocoa -framework Carbon -framework CoreGraphics -framework ApplicationServices
 #include <stdint.h>
 #import <Cocoa/Cocoa.h>
 #import <Carbon/Carbon.h>

--- a/hotkey_darwin.m
+++ b/hotkey_darwin.m
@@ -63,3 +63,101 @@ int unregisterHotKey(EventHotKeyRef ref) {
 	}
 	return 0;
 }
+
+// --- Media keys via CGEventTap ---
+//
+// Media keys (play/pause, next, previous, volume) are not Carbon hot keys;
+// they are delivered as NSSystemDefined events (type 14, subtype 8). We tap
+// the session event stream, decode the embedded NX_KEYTYPE code and the
+// up/down state, forward a matching press to Go, and consume the event.
+
+#define NX_SYSDEFINED 14
+
+typedef struct {
+	uintptr_t handle;
+	int nxKeyCode;
+	CFMachPortRef tap;
+	CFRunLoopSourceRef source;
+} mediaTap;
+
+static CGEventRef mediaTapCallback(CGEventTapProxy proxy, CGEventType type,
+                                   CGEventRef event, void *userInfo) {
+	mediaTap *mt = (mediaTap *)userInfo;
+
+	// The system disables a tap that is too slow or interrupted; re-enable it.
+	if (type == kCGEventTapDisabledByTimeout ||
+	    type == kCGEventTapDisabledByUserInput) {
+		if (mt->tap != NULL) {
+			CGEventTapEnable(mt->tap, true);
+		}
+		return event;
+	}
+
+	NSEvent *e = [NSEvent eventWithCGEvent:event];
+	if (e == nil || [e type] != NSEventTypeSystemDefined || [e subtype] != 8) {
+		return event;
+	}
+
+	int data1 = (int)[e data1];
+	int keyCode = (data1 & 0xffff0000) >> 16;
+	if (keyCode != mt->nxKeyCode) {
+		return event; // not the key this hotkey wants; pass through
+	}
+	int keyState = (data1 & 0x0000ff00) >> 8; // 0xA: down, 0xB: up
+	if (keyState == 0x0a) {
+		keydownCallback(mt->handle);
+	} else if (keyState == 0x0b) {
+		keyupCallback(mt->handle);
+	}
+	return NULL; // consume the event so the system does not also act on it
+}
+
+// registerMediaTap installs a CGEventTap for the given NX_KEYTYPE code.
+// Returns NULL on failure, most commonly because the application has not been
+// granted Accessibility (Input Monitoring) permission.
+void* registerMediaTap(uintptr_t handle, int nxKeyCode) {
+	mediaTap *mt = malloc(sizeof(mediaTap));
+	mt->handle = handle;
+	mt->nxKeyCode = nxKeyCode;
+	mt->tap = NULL;
+	mt->source = NULL;
+	dispatch_sync(dispatch_get_main_queue(), ^{
+		CGEventMask mask = CGEventMaskBit(NX_SYSDEFINED);
+		CFMachPortRef tap = CGEventTapCreate(
+			kCGSessionEventTap, kCGHeadInsertEventTap,
+			kCGEventTapOptionDefault, mask, mediaTapCallback, mt);
+		if (tap == NULL) {
+			return;
+		}
+		mt->tap = tap;
+		mt->source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0);
+		CFRunLoopAddSource(CFRunLoopGetMain(), mt->source, kCFRunLoopCommonModes);
+		CGEventTapEnable(tap, true);
+	});
+	if (mt->tap == NULL) {
+		free(mt);
+		return NULL;
+	}
+	return mt;
+}
+
+void unregisterMediaTap(void* p) {
+	if (p == NULL) {
+		return;
+	}
+	mediaTap *mt = (mediaTap *)p;
+	dispatch_sync(dispatch_get_main_queue(), ^{
+		if (mt->tap != NULL) {
+			CGEventTapEnable(mt->tap, false);
+		}
+		if (mt->source != NULL) {
+			CFRunLoopRemoveSource(CFRunLoopGetMain(), mt->source,
+			                      kCFRunLoopCommonModes);
+			CFRelease(mt->source);
+		}
+		if (mt->tap != NULL) {
+			CFRelease(mt->tap);
+		}
+	});
+	free(mt);
+}

--- a/hotkey_darwin.m
+++ b/hotkey_darwin.m
@@ -7,6 +7,7 @@
 //go:build darwin
 
 #include <stdint.h>
+#import <ApplicationServices/ApplicationServices.h>
 #import <Cocoa/Cocoa.h>
 #import <Carbon/Carbon.h>
 extern void keydownCallback(uintptr_t handle);
@@ -116,6 +117,13 @@ static CGEventRef mediaTapCallback(CGEventTapProxy proxy, CGEventType type,
 // Returns NULL on failure, most commonly because the application has not been
 // granted Accessibility (Input Monitoring) permission.
 void* registerMediaTap(uintptr_t handle, int nxKeyCode) {
+	// A keyboard event tap requires Accessibility (Input Monitoring) trust.
+	// Check explicitly: CGEventTapCreate can otherwise return a non-NULL but
+	// inert tap when untrusted, which would look like success but never fire.
+	if (!AXIsProcessTrusted()) {
+		return NULL;
+	}
+
 	mediaTap *mt = malloc(sizeof(mediaTap));
 	mt->handle = handle;
 	mt->nxKeyCode = nxKeyCode;


### PR DESCRIPTION
Completes media-key support (#28) on macOS — **Release 1** (Carbon for normal hotkeys + `CGEventTap` for media keys; full CGEventTap migration tracked in #45 as a later release).

## What shipped
- **Media key constants on macOS** matching Linux/Windows (`KeyMediaPlayPause/Next/Prev`, `KeyVolumeUp/Down/Mute`), encoded with a `mediaKeyBit` sentinel over the `NX_KEYTYPE_*` code. `register()` routes media keys to a `CGEventTap`; regular hotkeys keep using **Carbon** (no permission, macOS CI stays green).
- The tap decodes the `NSSystemDefined` `data1`, forwards keydown/keyup, and **consumes** the event so the system/Music.app does not also act on it.
- **Permission handling:** `AXIsProcessTrusted()` is checked up front, so a missing Accessibility/Input Monitoring grant is reported as a `Register()` error rather than a silent inert tap. `KeyMediaStop` has no `NX_KEYTYPE` equivalent on macOS and returns an error.
- **Example:** `examples/media/` — cross-platform, registers the media/volume keys and prints events, with platform notes (incl. how to grant Accessibility for a built binary on macOS).
- Bumped `examples/go.mod` to `go 1.24` (the local `replace` pulls in the hotkey module’s go requirement).

## Verification
- Build + link + existing Carbon tests pass on all platforms (CI green on the merged commit).
- Media-key runtime behavior is not CI-verifiable (runners lack Accessibility and media keys), so it was **manually verified on macOS**: events fire on press/release, the tap consumes the key (Now Playing does not also react), and the no-permission path returns a clean error without crashing.

Closes #28.