### PR TITLE
feat(darwin): unify all macOS hotkeys on CGEventTap, drop Carbon

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Note platform specific details:
   is possible. It is uncessary or applications based on other GUI frameworks,
   such as fyne, ebiten, or Gio. See the "[./examples](./examples)" folder
   for more examples.
+- On macOS, hotkeys are delivered through a CGEventTap, which requires the
+  application to be trusted for Accessibility (Input Monitoring). Without
+  that permission, `Register` returns an error; grant it in System Settings
+  → Privacy & Security → Accessibility.
 - On Linux (X11), when AutoRepeat is enabled in the X server, the Keyup
   is triggered automatically and continuously as Keydown continues.
 - On Linux (X11), some keys may be mapped to multiple Mod keys. To

--- a/export_darwin_test.go
+++ b/export_darwin_test.go
@@ -1,0 +1,11 @@
+// Copyright 2026 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+
+//go:build darwin && cgo
+
+package hotkey
+
+// AXTrusted exposes axTrusted to tests so they can skip when the process is
+// not trusted for Accessibility (e.g. on CI runners).
+var AXTrusted = axTrusted

--- a/hotkey.go
+++ b/hotkey.go
@@ -19,6 +19,11 @@
 //     is possible. It is uncessary or applications based on other GUI frameworks,
 //     such as fyne, ebiten, or Gio. See the "[examples]" for more examples.
 //
+//   - On macOS, hotkeys are delivered through a CGEventTap, which requires
+//     the application to be trusted for Accessibility (Input Monitoring).
+//     Without that permission, Register returns an error. Grant it in
+//     System Settings → Privacy & Security → Accessibility.
+//
 //   - On Linux (X11), when AutoRepeat is enabled in the X server, the
 //     Keyup is triggered automatically and continuously as Keydown continues.
 //

--- a/hotkey_darwin.go
+++ b/hotkey_darwin.go
@@ -10,20 +10,19 @@ package hotkey
 
 /*
 #cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Cocoa -framework Carbon -framework CoreGraphics -framework ApplicationServices
+#cgo LDFLAGS: -framework Cocoa -framework CoreGraphics -framework ApplicationServices
 #include <stdint.h>
 #import <Cocoa/Cocoa.h>
-#import <Carbon/Carbon.h>
 
 extern void keydownCallback(uintptr_t handle);
 extern void keyupCallback(uintptr_t handle);
-int registerHotKey(int mod, int key, uintptr_t handle, EventHotKeyRef* ref);
-int unregisterHotKey(EventHotKeyRef ref);
 
-// Media keys are not delivered through Carbon hot keys; they arrive as
-// NSSystemDefined events, captured here with a CGEventTap.
-void* registerMediaTap(uintptr_t handle, int nxKeyCode);
-void unregisterMediaTap(void* tap);
+// All hotkeys are delivered through a CGEventTap (regular keys and media
+// keys alike), so a single mechanism handles both. registerTap returns NULL
+// when the process lacks Accessibility (Input Monitoring) permission.
+void* registerTap(uintptr_t handle, int isMedia, int code, uint64_t flags);
+void unregisterTap(void* tap);
+int isAXTrusted();
 */
 import "C"
 import (
@@ -33,16 +32,26 @@ import (
 	"unsafe"
 )
 
-// Hotkey is a combination of modifiers and key to trigger an event
+// Hotkey is a combination of modifiers and key to trigger an event.
+//
+// On macOS every hotkey is served by a CGEventTap, which requires the
+// application to be trusted for Accessibility (Input Monitoring). Register
+// returns an error when that permission is missing.
 type platformHotkey struct {
 	mu         sync.Mutex
 	registered bool
-	hkref      C.EventHotKeyRef
-
-	// media-key registrations use a CGEventTap instead of a Carbon hot key.
-	mediaTap    unsafe.Pointer
-	mediaHandle cgo.Handle
+	tap        unsafe.Pointer
+	handle     cgo.Handle
 }
+
+// CGEventFlags modifier masks (see CGEventTypes.h), mapped from the package's
+// Carbon-style Modifier values.
+const (
+	cgFlagShift   = 0x20000
+	cgFlagControl = 0x40000
+	cgFlagOption  = 0x80000
+	cgFlagCommand = 0x100000
+)
 
 func (hk *Hotkey) register() error {
 	hk.mu.Lock()
@@ -51,47 +60,44 @@ func (hk *Hotkey) register() error {
 		return errAlreadyRegistered
 	}
 
+	var (
+		isMedia C.int
+		code    C.int
+		flags   C.uint64_t
+	)
 	if hk.key&mediaKeyBit != 0 {
-		return hk.registerMedia()
+		if hk.key == KeyMediaStop {
+			// There is no NX_KEYTYPE for media stop on macOS.
+			return errors.New("hotkey: media stop is not available on macOS")
+		}
+		isMedia = 1
+		code = C.int(hk.key &^ mediaKeyBit)
+	} else {
+		code = C.int(hk.key)
+		var f C.uint64_t
+		for _, m := range hk.mods {
+			switch m {
+			case ModCmd:
+				f |= cgFlagCommand
+			case ModShift:
+				f |= cgFlagShift
+			case ModOption:
+				f |= cgFlagOption
+			case ModCtrl:
+				f |= cgFlagControl
+			}
+		}
+		flags = f
 	}
-
-	// Note: we use handle number as hotkey id in the C side.
-	// A cgo handle could ran out of space, but since in hotkey purpose
-	// we won't have that much number of hotkeys. So this should be fine.
 
 	h := cgo.NewHandle(hk)
-	var mod Modifier
-	for _, m := range hk.mods {
-		mod += m
-	}
-
-	ret := C.registerHotKey(C.int(mod), C.int(hk.key), C.uintptr_t(h), &hk.hkref)
-	if ret == C.int(-1) {
-		return errRegisterFailed
-	}
-
-	hk.registered = true
-	return nil
-}
-
-// registerMedia registers a media key via a CGEventTap. Must be called with
-// hk.mu held.
-func (hk *Hotkey) registerMedia() error {
-	if hk.key == KeyMediaStop {
-		// There is no NX_KEYTYPE for media stop on macOS.
-		return errors.New("hotkey: media stop is not available on macOS")
-	}
-	nx := C.int(hk.key &^ mediaKeyBit)
-	h := cgo.NewHandle(hk)
-	tap := C.registerMediaTap(C.uintptr_t(h), nx)
+	tap := C.registerTap(C.uintptr_t(h), isMedia, code, flags)
 	if tap == nil {
 		h.Delete()
-		// CGEventTapCreate returns NULL without Accessibility/Input Monitoring
-		// permission.
-		return errors.New("hotkey: failed to register media key, grant the application Accessibility (Input Monitoring) permission")
+		return errors.New("hotkey: failed to register, grant the application Accessibility (Input Monitoring) permission")
 	}
-	hk.mediaTap = tap
-	hk.mediaHandle = h
+	hk.tap = tap
+	hk.handle = h
 	hk.registered = true
 	return nil
 }
@@ -102,22 +108,17 @@ func (hk *Hotkey) unregister() error {
 	if !hk.registered {
 		return errNotRegistered
 	}
-
-	if hk.mediaTap != nil {
-		C.unregisterMediaTap(hk.mediaTap)
-		hk.mediaTap = nil
-		hk.mediaHandle.Delete()
-		hk.registered = false
-		return nil
-	}
-
-	ret := C.unregisterHotKey(hk.hkref)
-	if ret == C.int(-1) {
-		return errors.New("hotkey: failed to unregister")
-	}
+	C.unregisterTap(hk.tap)
+	hk.tap = nil
+	hk.handle.Delete()
 	hk.registered = false
 	return nil
 }
+
+// axTrusted reports whether the process is trusted for Accessibility (Input
+// Monitoring). It is used by tests to skip when the environment cannot grant
+// permission (e.g. CI runners).
+func axTrusted() bool { return C.isAXTrusted() != 0 }
 
 //export keydownCallback
 func keydownCallback(h uintptr) {

--- a/hotkey_darwin.m
+++ b/hotkey_darwin.m
@@ -9,163 +9,162 @@
 #include <stdint.h>
 #import <ApplicationServices/ApplicationServices.h>
 #import <Cocoa/Cocoa.h>
-#import <Carbon/Carbon.h>
+
 extern void keydownCallback(uintptr_t handle);
 extern void keyupCallback(uintptr_t handle);
 
-static OSStatus
-keydownHandler(EventHandlerCallRef nextHandler, EventRef theEvent, void *userData) {
-	EventHotKeyID k;
-	GetEventParameter(theEvent, kEventParamDirectObject, typeEventHotKeyID, NULL, sizeof(k), NULL, &k);
-	keydownCallback((uintptr_t)k.id); // use id as handle
-	return noErr;
-}
+// isAXTrusted reports whether the process is trusted for Accessibility
+// (Input Monitoring), which a keyboard event tap requires.
+int isAXTrusted() { return AXIsProcessTrusted() ? 1 : 0; }
 
-static OSStatus
-keyupHandler(EventHandlerCallRef nextHandler, EventRef theEvent, void *userData) {
-	EventHotKeyID k;
-	GetEventParameter(theEvent, kEventParamDirectObject, typeEventHotKeyID, NULL, sizeof(k), NULL, &k);
-	keyupCallback((uintptr_t)k.id); // use id as handle
-	return noErr;
-}
-
-// registerHotkeyWithCallback registers a global system hotkey for callbacks.
-int registerHotKey(int mod, int key, uintptr_t handle, EventHotKeyRef* ref) {
-	__block OSStatus s;
-	dispatch_sync(dispatch_get_main_queue(), ^{
-		EventTypeSpec keydownEvent;
-		keydownEvent.eventClass = kEventClassKeyboard;
-		keydownEvent.eventKind = kEventHotKeyPressed;
-		EventTypeSpec keyupEvent;
-		keyupEvent.eventClass = kEventClassKeyboard;
-		keyupEvent.eventKind = kEventHotKeyReleased;
-		InstallApplicationEventHandler(
-			&keydownHandler, 1, &keydownEvent, NULL, NULL
-		);
-		InstallApplicationEventHandler(
-			&keyupHandler, 1, &keyupEvent, NULL, NULL
-		);
-
-		EventHotKeyID hkid = {.id = handle};
-		s = RegisterEventHotKey(
-			key, mod, hkid, GetApplicationEventTarget(), 0, ref
-		);
-	});
-	if (s != noErr) {
-		return -1;
-	}
-	return 0;
-}
-
-int unregisterHotKey(EventHotKeyRef ref) {
-	OSStatus s = UnregisterEventHotKey(ref);
-	if (s != noErr) {
-		return -1;
-	}
-	return 0;
-}
-
-// --- Media keys via CGEventTap ---
-//
-// Media keys (play/pause, next, previous, volume) are not Carbon hot keys;
-// they are delivered as NSSystemDefined events (type 14, subtype 8). We tap
-// the session event stream, decode the embedded NX_KEYTYPE code and the
-// up/down state, forward a matching press to Go, and consume the event.
+// All hotkeys (regular and media) are delivered through a CGEventTap rather
+// than Carbon RegisterEventHotKey, so a single mechanism handles both and the
+// tap can consume the event. This requires Accessibility (Input Monitoring)
+// permission; see registerTap.
 
 #define NX_SYSDEFINED 14
 
+// The modifier bits we match on (ignoring CapsLock, Fn, numeric pad, etc.).
+#define HOTKEY_MOD_MASK                                                        \
+	(kCGEventFlagMaskShift | kCGEventFlagMaskControl |                     \
+	 kCGEventFlagMaskAlternate | kCGEventFlagMaskCommand)
+
 typedef struct {
 	uintptr_t handle;
-	int nxKeyCode;
+	int isMedia;       // 1: NSSystemDefined media key; 0: regular key
+	int code;          // NX_KEYTYPE code (media) or CG keycode (regular)
+	uint64_t flags;    // required modifier mask (regular keys only)
+	int down;          // a keydown was delivered and not yet matched by keyup
 	CFMachPortRef tap;
 	CFRunLoopSourceRef source;
-} mediaTap;
+} eventTap;
 
-static CGEventRef mediaTapCallback(CGEventTapProxy proxy, CGEventType type,
-                                   CGEventRef event, void *userInfo) {
-	mediaTap *mt = (mediaTap *)userInfo;
+static CGEventRef tapCallback(CGEventTapProxy proxy, CGEventType type,
+                              CGEventRef event, void *userInfo) {
+	eventTap *t = (eventTap *)userInfo;
 
 	// The system disables a tap that is too slow or interrupted; re-enable it.
 	if (type == kCGEventTapDisabledByTimeout ||
 	    type == kCGEventTapDisabledByUserInput) {
-		if (mt->tap != NULL) {
-			CGEventTapEnable(mt->tap, true);
+		if (t->tap != NULL) {
+			CGEventTapEnable(t->tap, true);
 		}
 		return event;
 	}
 
-	NSEvent *e = [NSEvent eventWithCGEvent:event];
-	if (e == nil || [e type] != NSEventTypeSystemDefined || [e subtype] != 8) {
+	if (t->isMedia) {
+		NSEvent *e = [NSEvent eventWithCGEvent:event];
+		if (e == nil || [e type] != NSEventTypeSystemDefined ||
+		    [e subtype] != 8) {
+			return event;
+		}
+		int data1 = (int)[e data1];
+		int keyCode = (data1 & 0xffff0000) >> 16;
+		if (keyCode != t->code) {
+			return event; // not the key this hotkey wants
+		}
+		int keyState = (data1 & 0x0000ff00) >> 8; // 0xA: down, 0xB: up
+		if (keyState == 0x0a) {
+			keydownCallback(t->handle);
+		} else if (keyState == 0x0b) {
+			keyupCallback(t->handle);
+		}
+		return NULL; // consume
+	}
+
+	// Regular key.
+	if (type != kCGEventKeyDown && type != kCGEventKeyUp) {
 		return event;
 	}
-
-	int data1 = (int)[e data1];
-	int keyCode = (data1 & 0xffff0000) >> 16;
-	if (keyCode != mt->nxKeyCode) {
-		return event; // not the key this hotkey wants; pass through
+	int keycode =
+		(int)CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode);
+	if (keycode != t->code) {
+		return event;
 	}
-	int keyState = (data1 & 0x0000ff00) >> 8; // 0xA: down, 0xB: up
-	if (keyState == 0x0a) {
-		keydownCallback(mt->handle);
-	} else if (keyState == 0x0b) {
-		keyupCallback(mt->handle);
+	if (type == kCGEventKeyDown) {
+		uint64_t flags = CGEventGetFlags(event) & HOTKEY_MOD_MASK;
+		if (flags != t->flags) {
+			return event; // modifiers do not match this hotkey
+		}
+		// The tap repeats keyDown while the key is held; fire once.
+		if (!t->down) {
+			t->down = 1;
+			keydownCallback(t->handle);
+		}
+		return NULL; // consume
 	}
-	return NULL; // consume the event so the system does not also act on it
+	// keyUp: fire only if we delivered the matching keydown.
+	if (t->down) {
+		t->down = 0;
+		keyupCallback(t->handle);
+		return NULL;
+	}
+	return event;
 }
 
-// registerMediaTap installs a CGEventTap for the given NX_KEYTYPE code.
-// Returns NULL on failure, most commonly because the application has not been
-// granted Accessibility (Input Monitoring) permission.
-void* registerMediaTap(uintptr_t handle, int nxKeyCode) {
-	// A keyboard event tap requires Accessibility (Input Monitoring) trust.
-	// Check explicitly: CGEventTapCreate can otherwise return a non-NULL but
-	// inert tap when untrusted, which would look like success but never fire.
+// registerTap installs a CGEventTap. When isMedia is non-zero it taps the
+// NSSystemDefined stream and code is an NX_KEYTYPE; otherwise it taps the key
+// stream, code is a CG keycode and flags is the required modifier mask.
+// Returns NULL if the process is not trusted for Accessibility (Input
+// Monitoring) or the tap cannot be created.
+void* registerTap(uintptr_t handle, int isMedia, int code, uint64_t flags) {
+	// A keyboard event tap requires Accessibility trust. Check explicitly:
+	// CGEventTapCreate can otherwise return a non-NULL but inert tap when
+	// untrusted, which would look like success but never fire.
 	if (!AXIsProcessTrusted()) {
 		return NULL;
 	}
 
-	mediaTap *mt = malloc(sizeof(mediaTap));
-	mt->handle = handle;
-	mt->nxKeyCode = nxKeyCode;
-	mt->tap = NULL;
-	mt->source = NULL;
+	eventTap *t = malloc(sizeof(eventTap));
+	t->handle = handle;
+	t->isMedia = isMedia;
+	t->code = code;
+	t->flags = flags;
+	t->down = 0;
+	t->tap = NULL;
+	t->source = NULL;
 	dispatch_sync(dispatch_get_main_queue(), ^{
-		CGEventMask mask = CGEventMaskBit(NX_SYSDEFINED);
+		CGEventMask mask =
+			isMedia ? CGEventMaskBit(NX_SYSDEFINED)
+			        : (CGEventMaskBit(kCGEventKeyDown) |
+			           CGEventMaskBit(kCGEventKeyUp));
 		CFMachPortRef tap = CGEventTapCreate(
 			kCGSessionEventTap, kCGHeadInsertEventTap,
-			kCGEventTapOptionDefault, mask, mediaTapCallback, mt);
+			kCGEventTapOptionDefault, mask, tapCallback, t);
 		if (tap == NULL) {
 			return;
 		}
-		mt->tap = tap;
-		mt->source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0);
-		CFRunLoopAddSource(CFRunLoopGetMain(), mt->source, kCFRunLoopCommonModes);
+		t->tap = tap;
+		t->source =
+			CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0);
+		CFRunLoopAddSource(CFRunLoopGetMain(), t->source,
+		                   kCFRunLoopCommonModes);
 		CGEventTapEnable(tap, true);
 	});
-	if (mt->tap == NULL) {
-		free(mt);
+	if (t->tap == NULL) {
+		free(t);
 		return NULL;
 	}
-	return mt;
+	return t;
 }
 
-void unregisterMediaTap(void* p) {
+void unregisterTap(void* p) {
 	if (p == NULL) {
 		return;
 	}
-	mediaTap *mt = (mediaTap *)p;
+	eventTap *t = (eventTap *)p;
 	dispatch_sync(dispatch_get_main_queue(), ^{
-		if (mt->tap != NULL) {
-			CGEventTapEnable(mt->tap, false);
+		if (t->tap != NULL) {
+			CGEventTapEnable(t->tap, false);
 		}
-		if (mt->source != NULL) {
-			CFRunLoopRemoveSource(CFRunLoopGetMain(), mt->source,
+		if (t->source != NULL) {
+			CFRunLoopRemoveSource(CFRunLoopGetMain(), t->source,
 			                      kCFRunLoopCommonModes);
-			CFRelease(mt->source);
+			CFRelease(t->source);
 		}
-		if (mt->tap != NULL) {
-			CFRelease(mt->tap);
+		if (t->tap != NULL) {
+			CFRelease(t->tap);
 		}
 	});
-	free(mt);
+	free(t);
 }

--- a/hotkey_darwin_test.go
+++ b/hotkey_darwin_test.go
@@ -23,6 +23,9 @@ import (
 // Ctrl+Shift+S
 // Ctrl+Option+S
 func TestHotkey(t *testing.T) {
+	if !hotkey.AXTrusted() {
+		t.Skip("skipping: process is not trusted for Accessibility (Input Monitoring); grant permission to run this test")
+	}
 	tt := time.Second * 5
 	done := make(chan struct{}, 2)
 	ctx, cancel := context.WithTimeout(context.Background(), tt)


### PR DESCRIPTION
Implements #45 — **Release 2**: unify all macOS hotkeys on a single `CGEventTap` and drop Carbon `RegisterEventHotKey` entirely.

## What it does
One `CGEventTap` serves **both** regular hotkeys and media keys:
- **Regular keys:** matched by CG keycode + modifier flags (mapped from the package’s Carbon-style `Modifier` values), with keydown de-dup (the tap repeats while held) and keyup tracking. Matched events are **consumed**.
- **Media keys:** same tap, `NSSystemDefined` decode (unchanged behavior).
- Carbon is removed (`RegisterEventHotKey` / `InstallApplicationEventHandler` gone).

## Trade-off (the point of #45)
A keyboard event tap requires **Accessibility (Input Monitoring)** permission, so **every** macOS hotkey now needs it — not just media keys. `Register()` returns an error (via `AXIsProcessTrusted()`) when untrusted.

## ✅ Verified
- **CI green on all platforms** (19/19). Hosted macOS runners can’t grant Accessibility, so the macOS hotkey test skips when untrusted (`axTrusted`, exposed via `export_darwin_test.go`); Linux/Windows untouched.
- **Manually verified on macOS** (real hardware, with Accessibility granted): a regular hotkey (`Ctrl+Shift+S`) registers, fires Keydown/Keyup, **is consumed** (does not reach the focused app), and unregisters cleanly. Without permission, `Register()` errors cleanly.

## Docs
- Package doc + README updated to note the macOS Accessibility requirement for all hotkeys.

## Release note (do when v0.6.0 is cut) — privacy
This version installs a **global keyboard event tap** that **requires Accessibility / Input Monitoring** and can technically observe all keystrokes (used only to match registered hotkeys). Call this out explicitly in the release so users upgrade informed, and note sandboxed apps are affected.

Closes #45.